### PR TITLE
🚀 Add pipx installation support via `pyproject.toml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ To get started with `gpt-repository-loader`, follow these steps:
 
 5. The tool will generate an output.txt file containing the text representation of the repository. You can now use this file as input for AI language models or other text-based processing tasks.
 
+### Optional: Install via pipx
+
+You can also install and run the tool via pipx:
+
+```bash
+pipx install git+https://github.com/mpoon/gpt-repository-loader.git
+```
+
+Once installed, run it with:
+
+```bash
+gpt-repository-loader /path/to/git/repository [-p /path/to/preamble.txt] [-o /path/to/output_file.txt]
+```
+
 ## Running Tests
 
 To run the tests for `gpt-repository-loader`, follow these steps:

--- a/gpt_repository_loader/gpt_repository_loader.py
+++ b/gpt_repository_loader/gpt_repository_loader.py
@@ -32,9 +32,9 @@ def process_repository(repo_path, ignore_list, output_file):
                 output_file.write(f"{relative_file_path}\n")
                 output_file.write(f"{contents}\n")
 
-if __name__ == "__main__":
+def main():
     if len(sys.argv) < 2:
-        print("Usage: python git_to_text.py /path/to/git/repository [-p /path/to/preamble.txt] [-o /path/to/output_file.txt]")
+        print("Usage: python gpt_repository_loader.py /path/to/git/repository [-p /path/to/preamble.txt] [-o /path/to/output_file.txt]")
         sys.exit(1)
 
     repo_path = sys.argv[1]
@@ -71,4 +71,6 @@ if __name__ == "__main__":
     with open(output_file_path, 'a') as output_file:
         output_file.write("--END--")
     print(f"Repository contents written to {output_file_path}.")
-    
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "gpt-repository-loader"
+version = "0.1.0"
+description = "Tool to convert a Git repository into a plain-text format readable by AI models"
+dependencies = []
+requires-python = ">=3.7"
+
+[project.scripts]
+gpt-repository-loader = "gpt_repository_loader.gpt_repository_loader:main"
+
+[tool.setuptools]
+packages = ["gpt_repository_loader"]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/test_gpt_repository_loader.py
+++ b/test_gpt_repository_loader.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import tempfile
 import shutil
-from gpt_repository_loader import process_repository, get_ignore_list
+from gpt_repository_loader.gpt_repository_loader import process_repository, get_ignore_list
 
 
 class TestGPTRepositoryLoader(unittest.TestCase):


### PR DESCRIPTION
This PR adds support for installing and running `gpt-repository-loader` via [`pipx`](https://github.com/pypa/pipx), enabling:

```bash
pipx install git+https://github.com/mpoon/gpt-repository-loader.git
gpt-repository-loader /path/to/repo
```

---

### 🔧 Summary of Changes

- ✅ Moved `gpt_repository_loader.py` into a new `gpt_repository_loader/` package directory (required for `pipx` to correctly install)
- ✅ Moved the scripting inside the if __name__ == __main__ guard into a `main()` function and moved the guard to the end of `gpt_repository_loader.py` (this enables the gpt-repository-loader CLI script)
- ✅ Added a `pyproject.toml` with `[project.scripts]` entry for `gpt-repository-loader = "gpt_repository_loader.gpt_repository_loader:main"`
- ✅ Added `[tool.setuptools]` to restrict packaging to `gpt_repository_loader`,  otherwise `pipx` interprets the `test_data` folder as a package
- ✅ Updated the import statement in the test script to reflect the new package layout (i.e., import from `gpt_repository_loader.gpt_repository_loader` instead of just `gpt_repository_loader`)

---

### 🧪 Test Instructions

From the root of the project, you can now run:

```bash
pipx install --force --editable .
gpt-repository-loader /path/to/any/git/repo
```

To test directly from GitHub:

```bash
pipx install git+https://github.com/mgcooper/gpt-repository-loader.git@feat/pyproject.toml
```

If this PR is accepted, you can then install and access the cli tool:
```bash
pipx install git+https://github.com/mpoon/gpt-repository-loader.git
```

Several other PRs currently address the lack of a setup.py or pyproject.toml file. To my knowledge this is the most minimal refactor possible to address this, and enable pipx install, which many users will prefer.

Closes #63
